### PR TITLE
Remove unnecessary randomize() calls

### DIFF
--- a/Script/CandySpawner.gd
+++ b/Script/CandySpawner.gd
@@ -9,7 +9,6 @@ var active := []
 var idle := []
 
 func _ready():
-	randomize()
 	delay = lerp(3.0, 0.333, (global.level - global.firstLevel) / (global.lastLevel - global.firstLevel))
 	if global.level == global.lastLevel:
 		delay = 0.15

--- a/Script/Goober.gd
+++ b/Script/Goober.gd
@@ -10,7 +10,6 @@ var flip_clock := 1.0
 
 func _ready():
 	# change starting direction
-	randomize()
 	if randf() > 0.5:
 		flip()
 


### PR DESCRIPTION
https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html#class-globalscope-method-randomize says:

> Note: This function is called automatically when the project is run.

https://docs.godotengine.org/en/stable/tutorials/math/random_number_generation.html#the-randomize-method says:

> Since Godot 4.0, the random seed is automatically set to a random value when
> the project starts. This means you don't need to call randomize() in _ready()
> anymore to ensure that results are random across project runs.

We do not need to repeatedly reseed the global RNG.