### PR TITLE
Count levels dynamically

### DIFF
--- a/Script/Game.gd
+++ b/Script/Game.gd
@@ -1,6 +1,5 @@
 extends Node2D
 
-var tmpath := "res://TileMap/"
 enum {TILE_WALL = 0, TILE_PLAYER = 1, TILE_GOOBER = 2}
 var Map: TileMapLayer
 
@@ -43,9 +42,7 @@ func _process(delta):
 	MapChange(delta)
 
 func MapLoad():
-	var nxtlvl = min(global.level, global.lastLevel)
-	var tm = load(tmpath + str(nxtlvl) + ".tscn").instantiate()
-	tm.name = "TileMapLayer"
+	var tm = global.instantiate_level()
 	add_child(tm)
 	Map = tm
 

--- a/Script/Global.gd
+++ b/Script/Global.gd
@@ -1,16 +1,21 @@
 extends Node2D
 
+const DEFAULT_WORLD := "res://TileMap/"
+
+var _levels: Array[PackedScene]
 var level := 0
 const firstLevel := 0
-const lastLevel := 21
+var lastLevel: int
 var Game
 
 var OST = load("res://Audio/OST.mp3")
 var audio
 
 func _ready():
+	load_levels(DEFAULT_WORLD)
+
 	await get_tree().create_timer(0.1).timeout
-	
+
 	audio = AudioStreamPlayer.new()
 	add_child(audio)
 	audio.stream = OST
@@ -22,6 +27,35 @@ func _input(event):
 		var win_full = DisplayServer.window_get_mode() == DisplayServer.WINDOW_MODE_FULLSCREEN
 		DisplayServer.mouse_set_mode(DisplayServer.MOUSE_MODE_VISIBLE if win_full else DisplayServer.MOUSE_MODE_HIDDEN)
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED if win_full else DisplayServer.WINDOW_MODE_FULLSCREEN)
+
+## Load a series of numbered scenes from the given directory.
+## Each must be a TileMapLayer node.
+func load_levels(tilemap_dir: String):
+	_levels.clear()
+
+	var levelrx := RegEx.new()
+	levelrx.compile("^(\\d+).tscn$")
+
+	var level_paths: Array[String]
+	var dir := DirAccess.open(tilemap_dir)
+	dir.list_dir_begin()
+	var file := dir.get_next()
+	while file:
+		var rxmatch := levelrx.search(file)
+		if rxmatch:
+			level_paths.append(file)
+
+		file = dir.get_next()
+
+	level_paths.sort_custom(func (a: String, b: String): return a.naturalnocasecmp_to(b) < 0)
+	for path in level_paths:
+		var l := load(tilemap_dir.path_join(path)) as PackedScene
+		_levels.append(l)
+
+	lastLevel = _levels.size() - 1
+
+func instantiate_level() -> Node:
+	return _levels[level].instantiate()
 
 func wrapp(pos := Vector2.ZERO):
 	return Vector2(wrapf(pos.x, 0.0, 144.0), wrapf(pos.y, 0.0, 144.0))


### PR DESCRIPTION
Previously, the number of levels was hardcoded in the Global script, and would
have to match the number of scene files in the TileMap directory.

Instead, when Global is initialized, enumerate the numbered scene files in that
directory; sort them numerically; and load them for good measure. The number of
levels is then determined from the number of scenes found.

Fixes #5

Stacked on:

- #12 