### PR TITLE
Fix increasingly fast spawning of candies

### DIFF
--- a/Script/CandySpawner.gd
+++ b/Script/CandySpawner.gd
@@ -9,7 +9,7 @@ var active := []
 var idle := []
 
 func _ready():
-	delay = lerp(3.0, 0.333, (global.level - global.firstLevel) / (global.lastLevel - global.firstLevel))
+	delay = lerp(3.0, 0.333, float(global.level - global.firstLevel) / (global.lastLevel - global.firstLevel))
 	if global.level == global.lastLevel:
 		delay = 0.15
 


### PR DESCRIPTION
global.level, global.firstLevel, and global.lastLevel are all ints, so both sides of `(global.level - global.firstLevel) / (global.lastLevel - global.firstLevel)` are ints. So integer division is used, which rounds down. This means that, rather than the rate at which candies fall being a linear function of how far through the game you are, increasing in rate between one per 3 seconds and 3 per second, it actually stayed at one per 3 seconds throughout the game.

Use floating-point division instead by coercing the numerator to a float.