### PR TITLE
Add scrolling to world selector

### DIFF
--- a/Scene/WorldSelector.tscn
+++ b/Scene/WorldSelector.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=3 format=3 uid="uid://h6eyk0hg1y1f"]
+[gd_scene load_steps=5 format=3 uid="uid://h6eyk0hg1y1f"]
 
 [ext_resource type="Theme" uid="uid://dqt6eyc0l8kms" path="res://Theme/WorldSelector.tres" id="1_h1u7b"]
 [ext_resource type="Script" path="res://Script/WorldSelector.gd" id="2_c1jjg"]
+[ext_resource type="PackedScene" uid="uid://b1qffdabwqnxf" path="res://Scene/WorldSelector/ExtraWorldSelector.tscn" id="3_d8a1w"]
+[ext_resource type="PackedScene" uid="uid://pnnwgl5j385l" path="res://Scene/WorldSelector/MainWorldSelector.tscn" id="3_dc6jw"]
 
-[node name="TitleScreen" type="VBoxContainer"]
+[node name="TitleScreen" type="Control"]
+layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -12,49 +15,14 @@ grow_vertical = 2
 theme = ExtResource("1_h1u7b")
 script = ExtResource("2_c1jjg")
 
-[node name="Title" type="Label" parent="."]
-layout_mode = 2
-theme_type_variation = &"HeaderLarge"
-text = "Everlasting
-Candy"
-horizontal_alignment = 1
+[node name="MainWorldSelector" parent="." instance=ExtResource("3_dc6jw")]
+layout_mode = 1
 
-[node name="MarginContainer2" type="MarginContainer" parent="."]
-layout_mode = 2
-theme_override_constants/margin_left = 5
-theme_override_constants/margin_right = 5
-
-[node name="TabContainer" type="TabContainer" parent="MarginContainer2"]
-layout_mode = 2
-size_flags_vertical = 3
-current_tab = 0
-tabs_visible = false
-
-[node name="MainWorldBox" type="VBoxContainer" parent="MarginContainer2/TabContainer"]
-layout_mode = 2
-alignment = 1
-metadata/_tab_index = 0
-
-[node name="CandyWrapperButton" type="Button" parent="MarginContainer2/TabContainer/MainWorldBox"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "Play Candy Wrapper"
-
-[node name="ExtraWorldsButton" type="Button" parent="MarginContainer2/TabContainer/MainWorldBox"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "Extra Worlds"
-
-[node name="ExtraWorldsBox" type="VBoxContainer" parent="MarginContainer2/TabContainer"]
-unique_name_in_owner = true
+[node name="ExtraWorldSelector" parent="." instance=ExtResource("3_d8a1w")]
 visible = false
-layout_mode = 2
-metadata/_tab_index = 1
+layout_mode = 1
 
-[node name="BackButton" type="Button" parent="MarginContainer2/TabContainer/ExtraWorldsBox"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "Go Back"
-
-[connection signal="pressed" from="MarginContainer2/TabContainer/MainWorldBox/ExtraWorldsButton" to="." method="_on_extra_worlds_button_pressed"]
-[connection signal="pressed" from="MarginContainer2/TabContainer/ExtraWorldsBox/BackButton" to="." method="_on_back_button_pressed"]
+[connection signal="main_world_selected" from="MainWorldSelector" to="." method="_on_main_world_selected"]
+[connection signal="show_extra_worlds" from="MainWorldSelector" to="." method="_on_extra_worlds_button_pressed"]
+[connection signal="back" from="ExtraWorldSelector" to="." method="_on_back_button_pressed"]
+[connection signal="world_selected" from="ExtraWorldSelector" to="." method="_enter_world"]

--- a/Scene/WorldSelector/ExtraWorldSelector.tscn
+++ b/Scene/WorldSelector/ExtraWorldSelector.tscn
@@ -13,37 +13,48 @@ grow_vertical = 2
 theme = ExtResource("1_kkuy1")
 script = ExtResource("2_jpepg")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="Scroll" type="ScrollContainer" parent="."]
+unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+follow_focus = true
+horizontal_scroll_mode = 0
+vertical_scroll_mode = 2
+metadata/_edit_use_anchors_ = true
 
-[node name="Title" type="Label" parent="VBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Scroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="Scroll/VBoxContainer"]
 layout_mode = 2
 theme_type_variation = &"HeaderLarge"
 text = "Extra
 Worlds"
 horizontal_alignment = 1
 
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="Scroll/VBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/margin_left = 5
-theme_override_constants/margin_right = 5
+theme_override_constants/margin_right = 1
 theme_override_constants/margin_bottom = 5
 
-[node name="ExtraWorldsBox" type="VBoxContainer" parent="VBoxContainer/MarginContainer"]
+[node name="ExtraWorldsBox" type="VBoxContainer" parent="Scroll/VBoxContainer/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 2
 
-[node name="BackButton" type="Button" parent="VBoxContainer/MarginContainer/ExtraWorldsBox"]
+[node name="BackButton" type="Button" parent="Scroll/VBoxContainer/MarginContainer/ExtraWorldsBox"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Go Back"
 
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
-[connection signal="pressed" from="VBoxContainer/MarginContainer/ExtraWorldsBox/BackButton" to="." method="_on_back_button_pressed"]
+[connection signal="pressed" from="Scroll/VBoxContainer/MarginContainer/ExtraWorldsBox/BackButton" to="." method="_on_back_button_pressed"]

--- a/Scene/WorldSelector/ExtraWorldSelector.tscn
+++ b/Scene/WorldSelector/ExtraWorldSelector.tscn
@@ -1,0 +1,49 @@
+[gd_scene load_steps=3 format=3 uid="uid://b1qffdabwqnxf"]
+
+[ext_resource type="Theme" uid="uid://dqt6eyc0l8kms" path="res://Theme/WorldSelector.tres" id="1_kkuy1"]
+[ext_resource type="Script" path="res://Script/WorldSelector/ExtraWorldSelector.gd" id="2_jpepg"]
+
+[node name="ExtraWorldSelector" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_kkuy1")
+script = ExtResource("2_jpepg")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Title" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+theme_type_variation = &"HeaderLarge"
+text = "Extra
+Worlds"
+horizontal_alignment = 1
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="ExtraWorldsBox" type="VBoxContainer" parent="VBoxContainer/MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 2
+
+[node name="BackButton" type="Button" parent="VBoxContainer/MarginContainer/ExtraWorldsBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Go Back"
+
+[connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
+[connection signal="pressed" from="VBoxContainer/MarginContainer/ExtraWorldsBox/BackButton" to="." method="_on_back_button_pressed"]

--- a/Scene/WorldSelector/MainWorldSelector.tscn
+++ b/Scene/WorldSelector/MainWorldSelector.tscn
@@ -1,0 +1,51 @@
+[gd_scene load_steps=3 format=3 uid="uid://pnnwgl5j385l"]
+
+[ext_resource type="Theme" uid="uid://dqt6eyc0l8kms" path="res://Theme/WorldSelector.tres" id="1_2q1s0"]
+[ext_resource type="Script" path="res://Script/WorldSelector/MainWorldSelector.gd" id="1_g8fqa"]
+
+[node name="MainWorldSelector" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_g8fqa")
+
+[node name="VBox" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_2q1s0")
+
+[node name="Title" type="Label" parent="VBox"]
+layout_mode = 2
+theme_type_variation = &"HeaderLarge"
+text = "Everlasting
+Candy"
+horizontal_alignment = 1
+
+[node name="MarginContainer2" type="MarginContainer" parent="VBox"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_right = 5
+
+[node name="MainWorldBox" type="VBoxContainer" parent="VBox/MarginContainer2"]
+layout_mode = 2
+alignment = 1
+
+[node name="CandyWrapperButton" type="Button" parent="VBox/MarginContainer2/MainWorldBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Play Candy Wrapper"
+
+[node name="ExtraWorldsButton" type="Button" parent="VBox/MarginContainer2/MainWorldBox"]
+layout_mode = 2
+text = "Extra Worlds"
+
+[connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
+[connection signal="pressed" from="VBox/MarginContainer2/MainWorldBox/CandyWrapperButton" to="." method="_on_candy_wrapper_button_pressed"]
+[connection signal="pressed" from="VBox/MarginContainer2/MainWorldBox/ExtraWorldsButton" to="." method="_on_extra_worlds_button_pressed"]

--- a/Script/WorldSelector.gd
+++ b/Script/WorldSelector.gd
@@ -1,59 +1,27 @@
-extends VBoxContainer
-
-const WORLDS_DIR := "res://Worlds/"
+extends Control
 
 var _game := preload("res://Scene/Game.tscn") as PackedScene
 
-@onready var CandyWrapperButton: Button = %CandyWrapperButton
-@onready var ExtraWorldsButton: Button = %ExtraWorldsButton
-@onready var ExtraWorldsBox: VBoxContainer = %ExtraWorldsBox
-@onready var BackButton: Button = %BackButton
+@onready var MainWorldSelector = $MainWorldSelector
+@onready var ExtraWorldSelector = $ExtraWorldSelector
 
 
-func _find_worlds(path) -> Array[String]:
-	var worlds_dir = DirAccess.open(path)
-	var worlds: Array[String]
-	if worlds_dir:
-		worlds_dir.list_dir_begin()
-		var child := worlds_dir.get_next()
-		while child:
-			if worlds_dir.current_is_dir():
-				worlds.append(child)
-			child = worlds_dir.get_next()
-	return worlds
-
-
-func _ready() -> void:
-	var worlds := _find_worlds(WORLDS_DIR)
-
-	for world in worlds:
-		var button = Button.new()
-		button.text = world
-		button.pressed.connect(_on_world_button_pressed.bind(WORLDS_DIR.path_join(world)))
-		ExtraWorldsBox.add_child(button)
-
-	CandyWrapperButton.pressed.connect(_on_world_button_pressed.bind(global.DEFAULT_WORLD))
-	CandyWrapperButton.grab_focus()
-
-
-func _on_world_button_pressed(world: String) -> void:
+func _enter_world(world: String) -> void:
 	global.load_levels(world)
 	global.level = global.firstLevel
 	get_tree().change_scene_to_packed(_game)
 	global.start_music()
 
 
+func _on_main_world_selected() -> void:
+	_enter_world(global.DEFAULT_WORLD)
+
+
 func _on_extra_worlds_button_pressed() -> void:
-	ExtraWorldsBox.show()
-	BackButton.grab_focus()
+	MainWorldSelector.visible = false
+	ExtraWorldSelector.visible = true
 
 
 func _on_back_button_pressed() -> void:
-	ExtraWorldsBox.hide()
-	CandyWrapperButton.grab_focus.call_deferred()
-
-
-func _input(event: InputEvent) -> void:
-	if event.is_action_pressed("ui_cancel"):
-		if ExtraWorldsBox.visible:
-			_on_back_button_pressed()
+	ExtraWorldSelector.visible = false
+	MainWorldSelector.visible = true

--- a/Script/WorldSelector/ExtraWorldSelector.gd
+++ b/Script/WorldSelector/ExtraWorldSelector.gd
@@ -1,0 +1,50 @@
+extends Control
+
+signal world_selected(world: String)
+signal back
+
+const WORLDS_DIR := "res://Worlds/"
+
+@onready var ExtraWorldsBox: VBoxContainer = %ExtraWorldsBox
+@onready var BackButton: Button = %BackButton
+
+
+func _find_worlds(path) -> Array[String]:
+	var worlds_dir = DirAccess.open(path)
+	var worlds: Array[String]
+	if worlds_dir:
+		worlds_dir.list_dir_begin()
+		var child := worlds_dir.get_next()
+		while child:
+			if worlds_dir.current_is_dir():
+				worlds.append(child)
+			child = worlds_dir.get_next()
+	return worlds
+
+
+func _ready() -> void:
+	var worlds := _find_worlds(WORLDS_DIR)
+
+	for world in worlds:
+		var button = Button.new()
+		button.text = world
+		button.pressed.connect(_on_world_button_pressed.bind(WORLDS_DIR.path_join(world)))
+		ExtraWorldsBox.add_child(button)
+
+
+func _on_world_button_pressed(world: String) -> void:
+	world_selected.emit(world)
+
+
+func _on_back_button_pressed() -> void:
+	back.emit()
+
+
+func _input(event: InputEvent) -> void:
+	if self.visible and event.is_action_pressed("ui_cancel"):
+		back.emit()
+
+
+func _on_visibility_changed() -> void:
+	if self.visible and BackButton:
+		BackButton.grab_focus()

--- a/Script/WorldSelector/ExtraWorldSelector.gd
+++ b/Script/WorldSelector/ExtraWorldSelector.gd
@@ -5,6 +5,7 @@ signal back
 
 const WORLDS_DIR := "res://Worlds/"
 
+@onready var Scroll: ScrollContainer = %Scroll
 @onready var ExtraWorldsBox: VBoxContainer = %ExtraWorldsBox
 @onready var BackButton: Button = %BackButton
 
@@ -48,3 +49,4 @@ func _input(event: InputEvent) -> void:
 func _on_visibility_changed() -> void:
 	if self.visible and BackButton:
 		BackButton.grab_focus()
+		Scroll.scroll_vertical = 0

--- a/Script/WorldSelector/MainWorldSelector.gd
+++ b/Script/WorldSelector/MainWorldSelector.gd
@@ -1,0 +1,22 @@
+extends Control
+
+signal main_world_selected
+signal show_extra_worlds
+
+@onready var CandyWrapperButton = %CandyWrapperButton
+
+func _ready() -> void:
+	CandyWrapperButton.grab_focus()
+
+
+func _on_candy_wrapper_button_pressed() -> void:
+	main_world_selected.emit()
+
+
+func _on_extra_worlds_button_pressed() -> void:
+	show_extra_worlds.emit()
+
+
+func _on_visibility_changed() -> void:
+	if self.visible and CandyWrapperButton:
+		CandyWrapperButton.grab_focus()

--- a/Theme/WorldSelector.tres
+++ b/Theme/WorldSelector.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=6 format=3 uid="uid://dqt6eyc0l8kms"]
+[gd_resource type="Theme" load_steps=8 format=3 uid="uid://dqt6eyc0l8kms"]
 
 [ext_resource type="FontFile" uid="uid://2q38bblqh3yd" path="res://Font/Border_Basic.ttf" id="1_32alm"]
 [ext_resource type="FontFile" uid="uid://d3xp4agbq2lok" path="res://Font/m3x6.ttf" id="2_6rcqi"]
@@ -20,6 +20,13 @@ anti_aliasing = false
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_poevj"]
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5ip3m"]
+bg_color = Color(0.996078, 0.615686, 0.0862745, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4anqa"]
+border_width_right = 4
+border_color = Color(0.454902, 0.192157, 0.00392157, 1)
+
 [resource]
 default_font = ExtResource("2_6rcqi")
 Button/colors/font_color = Color(0.996078, 0.615686, 0.0862745, 1)
@@ -40,3 +47,8 @@ HeaderLarge/font_sizes/font_size = 16
 HeaderLarge/fonts/font = ExtResource("1_32alm")
 Label/colors/font_color = Color(0.996078, 0.615686, 0.0862745, 1)
 TabContainer/styles/panel = SubResource("StyleBoxEmpty_poevj")
+VScrollBar/styles/grabber = SubResource("StyleBoxFlat_5ip3m")
+VScrollBar/styles/grabber_highlight = SubResource("StyleBoxFlat_5ip3m")
+VScrollBar/styles/grabber_pressed = SubResource("StyleBoxFlat_5ip3m")
+VScrollBar/styles/scroll = SubResource("StyleBoxFlat_4anqa")
+VScrollBar/styles/scroll_focus = SubResource("StyleBoxFlat_4anqa")


### PR DESCRIPTION
Once we have 4 extra worlds, they will not fit vertically into the game window.

Add vertical scrolling. Include the whole page in the scroll, including the back
button and title, so that as many worlds as possible fit. Ensure the focused
button is always in view, so that they can be navigated with a gamepad or arrow
keys.

The scrollbar is set to be 4 pixels wide, and always visible; the right margin
of the page is adjusted to make room for it. This is ugly while we don't need
it, but simpler than trying to hide it when it's not needed.

Fixes https://github.com/endlessm/everlasting-candy/issues/26