### PR TITLE
Remove unused nodes from Game scene

### DIFF
--- a/Scene/Game.tscn
+++ b/Scene/Game.tscn
@@ -9,8 +9,6 @@
 [node name="Game" type="Node2D"]
 script = ExtResource("1")
 
-[node name="HUD" type="CanvasLayer" parent="."]
-
 [node name="CandySpawner" type="Node2D" parent="."]
 script = ExtResource("2")
 

--- a/Scene/Game.tscn
+++ b/Scene/Game.tscn
@@ -11,9 +11,6 @@ script = ExtResource("1")
 
 [node name="HUD" type="CanvasLayer" parent="."]
 
-[node name="Camera2D" type="Camera2D" parent="."]
-offset = Vector2(72, 72)
-
 [node name="CandySpawner" type="Node2D" parent="."]
 script = ExtResource("2")
 


### PR DESCRIPTION
The Game scene contains an unused Camera2D, and an unused CanvasLayer named "HUD". Remove both.