### PR TITLE
Set loop property on OST sample

### DIFF
--- a/Audio/OST.mp3.import
+++ b/Audio/OST.mp3.import
@@ -12,8 +12,8 @@ dest_files=["res://.godot/imported/OST.mp3-78d56ac9161581bbb1b6382065d0e63a.mp3s
 
 [params]
 
-loop=false
-loop_offset=0
-bpm=0
+loop=true
+loop_offset=0.0
+bpm=0.0
 beat_count=0
 bar_beats=4

--- a/Script/Global.gd
+++ b/Script/Global.gd
@@ -19,7 +19,6 @@ func _ready():
 	audio = AudioStreamPlayer.new()
 	add_child(audio)
 	audio.stream = OST
-	audio.finished.connect(audio.play)
 
 func _input(event):
 	if event.is_action_pressed("ui_fullscreen"):


### PR DESCRIPTION
Previously, the OST was not set to loop; instead, a signal handler was connected to the finished signal on the AudioStreamPlayer that restarted the stream.

Instead, set the loop property on the imported sample, and remove the signal handler.