### PR TITLE
Revert "Goober: Add uid for script"

### DIFF
--- a/Scene/Goober.tscn
+++ b/Scene/Goober.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=7 format=3 uid="uid://byheefdx4lxmx"]
 
-[ext_resource type="Script" uid="uid://c5dx3r1l6mwox" path="res://Script/Goober.gd" id="1"]
+[ext_resource type="Script" path="res://Script/Goober.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://cn5awui7bqekp" path="res://Image/Goober.png" id="2"]
 
 [sub_resource type="RectangleShape2D" id="1"]


### PR DESCRIPTION
This reverts commit 56406f52932a469e0da33066d33e2a0328f1f586 from https://github.com/endlessm/everlasting-candy/pull/29.

    W 0:00:05:0140   Game.gd:7 @ @implicit_new(): res://Scene/Goober.tscn:3 - ext_resource, invalid UID: uid://c5dx3r1l6mwox - using text path instead: res://Script/Goober.gd
      <C++ Source>   scene/resources/resource_format_text.cpp:453 @ load()
      <Stack Trace>  Game.gd:7 @ @implicit_new()
                     WorldSelector.gd:42 @ _on_world_button_pressed()

I believe that UIDs for scripts are more a Godot 4.4 thing. I don't know why this one kept being added in my local copy.