### PR TITLE
Player: Emit signals on contact with goobers

### DIFF
--- a/Script/Game.gd
+++ b/Script/Game.gd
@@ -18,8 +18,6 @@ var check := false
 var change := false
 
 func _ready():
-	global.Game = self
-
 	if global.level == global.firstLevel or global.level == global.lastLevel:
 		NodeSprite.frame = 0 if global.level == global.firstLevel else 3
 		NodeSprite.visible = true
@@ -64,6 +62,8 @@ func MapStart():
 				var inst = ScenePlayer.instantiate()
 				inst.position = Map.map_to_local(pos) + Vector2(4, 0)
 				self.add_child(inst)
+				inst.died.connect(_on_died.bind(inst))
+				inst.stomped.connect(_on_stomped)
 				# Remove static player tile from the tile map
 				Map.set_cell(pos, -1)
 			TILE_GOOBER:
@@ -108,7 +108,16 @@ func DoChange():
 	change = false
 	get_tree().reload_current_scene()
 
-func Explode(arg : Vector2):
+func Explode(character: Node2D):
 	var xpl = SceneExplo.instantiate()
-	xpl.position = arg
+	xpl.position = character.position
 	add_child(xpl)
+	character.queue_free()
+
+func _on_died(player: CharacterBody2D):
+	Explode(player)
+	Lose()
+
+func _on_stomped(goober: CharacterBody2D):
+	Explode(goober)
+	check = true

--- a/Script/Global.gd
+++ b/Script/Global.gd
@@ -6,7 +6,6 @@ var _levels: Array[PackedScene]
 var level := 0
 const firstLevel := 0
 var lastLevel: int
-var Game
 
 var OST = load("res://Audio/OST.mp3")
 var audio

--- a/Script/Player.gd
+++ b/Script/Player.gd
@@ -1,6 +1,8 @@
 extends CharacterBody2D
 
-@onready var NodeScene = global.Game
+signal stomped(goober: CharacterBody2D)
+signal died
+
 @onready var NodeSprite := $Sprite2D
 @onready var NodeArea2D := $Area2D
 @onready var NodeAudio := $Audio
@@ -60,10 +62,6 @@ func _physics_process(delta):
 	else:
 		TryLoop("Jump")
 
-func Die():
-	queue_free()
-	NodeScene.Explode(position)
-	NodeScene.Lose()
 
 func Overlap():
 	var hit = false
@@ -76,16 +74,13 @@ func Overlap():
 			var above = position.y - 1 < par.position.y
 			
 			if onFloor or (vel.y < 0.0 and !above):
-				Die()
+				died.emit()
 			else:
 				hit = true
 				jump = Input.is_action_pressed("jump")
 				vel.y = -jumpSpd * (1.0 if jump else 0.6)
 				
-				par.queue_free()
-				NodeScene.Explode(par.position)
-				NodeScene.check = true
-				print("Goober destroyed")
+				stomped.emit(par)
 	return hit
 
 func TryLoop(arg : String):


### PR DESCRIPTION
Previously, Player would directly call methods on the Game scene instance (accessed via a global variable) when it either stomps on an enemy, or dies.

Instead, emit signals from Player and connect to them from Game to run the same logic.

Since this was the only use of the global variable, remove it.