### PR TITLE
Introduce World scene for each world

### DIFF
--- a/CandyWrapper/World.tscn
+++ b/CandyWrapper/World.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=4 format=3 uid="uid://dl2mvatn1hkiq"]
+
+[ext_resource type="Script" path="res://Script/World.gd" id="1_prt4d"]
+[ext_resource type="Script" path="res://Script/CandySpawner.gd" id="2_kuf4p"]
+[ext_resource type="AudioStream" uid="uid://7sq3il53l6oa" path="res://Audio/OST.mp3" id="2_swba7"]
+
+[node name="World" type="Node2D"]
+script = ExtResource("1_prt4d")
+
+[node name="CandySpawner" type="Node2D" parent="."]
+script = ExtResource("2_kuf4p")
+
+[node name="Music" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("2_swba7")
+autoplay = true

--- a/CandyWrapper/World.tscn
+++ b/CandyWrapper/World.tscn
@@ -1,14 +1,13 @@
 [gd_scene load_steps=4 format=3 uid="uid://dl2mvatn1hkiq"]
 
 [ext_resource type="Script" path="res://Script/World.gd" id="1_prt4d"]
-[ext_resource type="Script" path="res://Script/CandySpawner.gd" id="2_kuf4p"]
 [ext_resource type="AudioStream" uid="uid://7sq3il53l6oa" path="res://Audio/OST.mp3" id="2_swba7"]
+[ext_resource type="PackedScene" uid="uid://ddy88bnd0h5it" path="res://Scene/CandySpawner.tscn" id="2_vsd7d"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("1_prt4d")
 
-[node name="CandySpawner" type="Node2D" parent="."]
-script = ExtResource("2_kuf4p")
+[node name="CandySpawner" parent="." instance=ExtResource("2_vsd7d")]
 
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_swba7")

--- a/CandyWrapper/World.tscn
+++ b/CandyWrapper/World.tscn
@@ -1,14 +1,33 @@
-[gd_scene load_steps=4 format=3 uid="uid://dl2mvatn1hkiq"]
+[gd_scene load_steps=7 format=3 uid="uid://dl2mvatn1hkiq"]
 
 [ext_resource type="Script" path="res://Script/World.gd" id="1_prt4d"]
 [ext_resource type="AudioStream" uid="uid://7sq3il53l6oa" path="res://Audio/OST.mp3" id="2_swba7"]
 [ext_resource type="PackedScene" uid="uid://ddy88bnd0h5it" path="res://Scene/CandySpawner.tscn" id="2_vsd7d"]
+[ext_resource type="Texture2D" uid="uid://ccxmd1v0nd7wi" path="res://Image/Title.png" id="4_rs0wp"]
+[ext_resource type="AudioStream" uid="uid://bu4rmhfiu1mm5" path="res://Audio/Win.ogg" id="5_qdrvr"]
+[ext_resource type="AudioStream" uid="uid://dgnfi0xvfvhnx" path="res://Audio/Lose.wav" id="6_rs0e0"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("1_prt4d")
 
 [node name="CandySpawner" parent="." instance=ExtResource("2_vsd7d")]
 
+[node name="Overlay" type="Sprite2D" parent="."]
+visible = false
+z_index = 5
+texture = ExtResource("4_rs0wp")
+centered = false
+hframes = 4
+frame = 1
+
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_swba7")
 autoplay = true
+
+[node name="Audio" type="Node" parent="."]
+
+[node name="Win" type="AudioStreamPlayer" parent="Audio"]
+stream = ExtResource("5_qdrvr")
+
+[node name="Lose" type="AudioStreamPlayer" parent="Audio"]
+stream = ExtResource("6_rs0e0")

--- a/Scene/CandySpawner.tscn
+++ b/Scene/CandySpawner.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://ddy88bnd0h5it"]
+
+[ext_resource type="Script" path="res://Script/CandySpawner.gd" id="1_70aw3"]
+
+[node name="CandySpawner" type="Node2D"]
+script = ExtResource("1_70aw3")

--- a/Scene/Game.tscn
+++ b/Scene/Game.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=6 format=3 uid="uid://cnbp88623k5jh"]
 
 [ext_resource type="Script" path="res://Script/Game.gd" id="1"]
-[ext_resource type="Script" path="res://Script/CandySpawner.gd" id="2"]
+[ext_resource type="PackedScene" uid="uid://pym0lb1onu1n" path="res://CandyWrapper/1.tscn" id="2_8211u"]
 [ext_resource type="AudioStream" uid="uid://bu4rmhfiu1mm5" path="res://Audio/Win.ogg" id="3"]
 [ext_resource type="Texture2D" uid="uid://ccxmd1v0nd7wi" path="res://Image/Title.png" id="3_rwxge"]
 [ext_resource type="AudioStream" uid="uid://dgnfi0xvfvhnx" path="res://Audio/Lose.wav" id="4"]
@@ -9,8 +9,7 @@
 [node name="Game" type="Node2D"]
 script = ExtResource("1")
 
-[node name="CandySpawner" type="Node2D" parent="."]
-script = ExtResource("2")
+[node name="Map" parent="." instance=ExtResource("2_8211u")]
 
 [node name="Goobers" type="Node2D" parent="."]
 

--- a/Scene/Game.tscn
+++ b/Scene/Game.tscn
@@ -1,10 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://cnbp88623k5jh"]
+[gd_scene load_steps=3 format=3 uid="uid://cnbp88623k5jh"]
 
 [ext_resource type="Script" path="res://Script/Game.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://pym0lb1onu1n" path="res://CandyWrapper/1.tscn" id="2_8211u"]
-[ext_resource type="AudioStream" uid="uid://bu4rmhfiu1mm5" path="res://Audio/Win.ogg" id="3"]
-[ext_resource type="Texture2D" uid="uid://ccxmd1v0nd7wi" path="res://Image/Title.png" id="3_rwxge"]
-[ext_resource type="AudioStream" uid="uid://dgnfi0xvfvhnx" path="res://Audio/Lose.wav" id="4"]
 
 [node name="Game" type="Node2D"]
 script = ExtResource("1")
@@ -12,19 +9,3 @@ script = ExtResource("1")
 [node name="Map" parent="." instance=ExtResource("2_8211u")]
 
 [node name="Goobers" type="Node2D" parent="."]
-
-[node name="Sprite2D" type="Sprite2D" parent="."]
-visible = false
-z_index = 5
-texture = ExtResource("3_rwxge")
-centered = false
-hframes = 4
-frame = 1
-
-[node name="Audio" type="Node" parent="."]
-
-[node name="Win" type="AudioStreamPlayer" parent="Audio"]
-stream = ExtResource("3")
-
-[node name="Lose" type="AudioStreamPlayer" parent="Audio"]
-stream = ExtResource("4")

--- a/Script/CandySpawner.gd
+++ b/Script/CandySpawner.gd
@@ -9,10 +9,12 @@ extends Node2D
 @export_range(0.0, 1.0) var progress := 0.0:
 	set = _set_progress
 
+## The texture to use for the candy falling in the background.
+@export var candy_texture: Texture2D = preload("res://Image/Candy.png")
+
 var delay := 3.0
 var timer := 0.0
 
-var candy_tex = preload("res://Image/Candy.png")
 
 var active := []
 var idle := []
@@ -48,7 +50,7 @@ func _process(delta):
 			c = idle.pop_back()
 		else:
 			c = Sprite2D.new()
-			c.texture = candy_tex
+			c.texture = candy_texture
 			c.z_index = -1
 			add_child(c)
 		active.append(c)

--- a/Script/CandySpawner.gd
+++ b/Script/CandySpawner.gd
@@ -1,4 +1,13 @@
+## Simulates candy falling from the sky behind the game level. The spawn rate
+## increases as the player progresses through the levels; this is controlled
+## with [member progress].
+class_name CandySpawner
 extends Node2D
+
+## The progress of the player through the game, from 0.0 (on the title screen)
+## to 1.0 (on the win screen). Candy spawns faster as this value increases.
+@export_range(0.0, 1.0) var progress := 0.0:
+	set = _set_progress
 
 var delay := 3.0
 var timer := 0.0
@@ -8,22 +17,30 @@ var candy_tex = preload("res://Image/Candy.png")
 var active := []
 var idle := []
 
-func _ready():
-	delay = lerp(3.0, 0.333, float(global.level - global.firstLevel) / (global.lastLevel - global.firstLevel))
-	if global.level == global.lastLevel:
+
+func _set_progress(new_progress):
+	progress = new_progress
+
+	var old_delay = delay
+	if progress >= 1:
 		delay = 0.15
+	else:
+		delay = lerp(3.0, 0.333, progress)
+
+	timer -= (old_delay - delay)
+
 
 func _process(delta):
 	timer -= delta
-	
+
 	for i in active:
 		i.position.y += 60.0 * delta
 		if i.position.y > 160:
 			idle.append(i)
-	
+
 	for i in idle:
 		active.erase(i)
-	
+
 	if timer < 0:
 		timer = delay
 		var c

--- a/Script/Game.gd
+++ b/Script/Game.gd
@@ -15,20 +15,11 @@ var SceneGoober = load("res://Scene/Goober.tscn")
 var SceneExplo = load("res://Scene/Explosion.tscn")
 
 @onready var NodeGoobers := $Goobers
-@onready var NodeAudioWin := $Audio/Win
-@onready var NodeAudioLose := $Audio/Lose
-@onready var NodeSprite := $Sprite2D
 
-var clock := 0.0
-var delay := 1.5
 var check := false
-var change := false
-var died := false
 
 func _ready():
 	if level_type != LevelType.NORMAL:
-		NodeSprite.frame = 0 if level_type == LevelType.TITLE else 3
-		NodeSprite.visible = true
 		var p = ScenePlayer.instantiate()
 		p.position = Vector2(72, 85)
 		p.scale.x = -1 if randf() < 0.5 else 1
@@ -36,14 +27,6 @@ func _ready():
 		add_child(p)
 
 	MapStart()
-
-func _process(delta):
-	clock += delta
-
-	if Input.is_action_just_pressed("jump") and level_type != LevelType.NORMAL:
-		win.emit()
-
-	MapChange(delta)
 
 func MapStart():
 	for pos in Map.get_used_cells():
@@ -70,40 +53,14 @@ func MapStart():
 				# Remove static goober tile from the tile map
 				Map.set_cell(pos, -1)
 
-func MapChange(delta):
-	# if its time to change scene
-	if change:
-		delay -= delta
-		if delay < 0:
-			DoChange()
-		return # skip the rest if change == true
-
+func _process(_delta: float):
 	# should i check?
 	if check:
 		check = false
 		var count = NodeGoobers.get_child_count()
 		print("Goobers: ", count)
 		if count == 0:
-			Win()
-
-func Lose():
-	change = true
-	NodeAudioLose.play()
-	NodeSprite.visible = true
-	NodeSprite.frame = 2
-	died = true
-
-func Win():
-	change = true
-	NodeAudioWin.play()
-	NodeSprite.visible = true
-
-func DoChange():
-	change = false
-	if died:
-		lose.emit()
-	else:
-		win.emit()
+			win.emit()
 
 func Explode(character: Node2D):
 	var xpl = SceneExplo.instantiate()
@@ -113,7 +70,7 @@ func Explode(character: Node2D):
 
 func _on_died(player: CharacterBody2D):
 	Explode(player)
-	Lose()
+	lose.emit()
 
 func _on_stomped(goober: CharacterBody2D):
 	Explode(goober)

--- a/Script/Global.gd
+++ b/Script/Global.gd
@@ -1,76 +1,11 @@
 extends Node2D
 
-const DEFAULT_WORLD := "res://CandyWrapper/"
-
-var _levels: Array[PackedScene]
-var level := 0
-const firstLevel := 0
-var lastLevel: int
-
-var OST = load("res://Audio/OST.mp3")
-var audio
-
-func _ready():
-	load_levels(DEFAULT_WORLD)
-
-	await get_tree().create_timer(0.1).timeout
-
-	audio = AudioStreamPlayer.new()
-	add_child(audio)
-	audio.stream = OST
-
 func _input(event):
 	if event.is_action_pressed("ui_fullscreen"):
 		var win_full = DisplayServer.window_get_mode() == DisplayServer.WINDOW_MODE_FULLSCREEN
 		DisplayServer.mouse_set_mode(DisplayServer.MOUSE_MODE_VISIBLE if win_full else DisplayServer.MOUSE_MODE_HIDDEN)
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED if win_full else DisplayServer.WINDOW_MODE_FULLSCREEN)
 
-## Lists scenes in the given resource directory, accounting for the fact that,
-## when exported, resource files are renamed, but must be loaded by their
-## original name.
-##
-## Returns the original basename of each scene in the given directory.
-##
-## TODO: in Godot 4.4, use ResourceLoader.list_directory()
-##  https://docs.godotengine.org/en/latest/classes/class_resourceloader.html#class-resourceloader-method-list-directory
-func _list_scenes(path: String) -> Array[String]:
-	var scenes: Array[String]
-	var dir := DirAccess.open(path)
-	
-	dir.list_dir_begin()
-	var file := dir.get_next()
-	while file:
-		if file.ends_with(".tscn.remap"):
-			scenes.append(file.left(-len(".remap")))
-		elif file.ends_with(".tscn"):
-			scenes.append(file)
-		file = dir.get_next()
-	dir.list_dir_end()
-
-	return scenes
-
-## Load a series of numbered scenes from the given directory.
-## Each must be a TileMapLayer node.
-func load_levels(tilemap_dir: String):
-	_levels.clear()
-
-	var scenes := _list_scenes(tilemap_dir)
-	scenes.sort_custom(func (a: String, b: String): return a.naturalnocasecmp_to(b) < 0)
-
-	for scene_filename in scenes:
-		var l := load(tilemap_dir.path_join(scene_filename)) as PackedScene
-		_levels.append(l)
-
-	lastLevel = _levels.size() - 1
-
-func instantiate_level() -> Node:
-	return _levels[level].instantiate()
-
-func start_music():
-	audio.play()
-
-func stop_music():
-	audio.stop()
 
 func wrapp(pos := Vector2.ZERO):
 	return Vector2(wrapf(pos.x, 0.0, 144.0), wrapf(pos.y, 0.0, 144.0))

--- a/Script/World.gd
+++ b/Script/World.gd
@@ -1,0 +1,91 @@
+extends Node2D
+
+var levels: Array[PackedScene]
+var level := 0
+const firstLevel := 0
+var lastLevel: int
+
+var _game_scene : PackedScene = preload("res://Scene/Game.tscn")
+var _game : Game
+@onready var _candy_spawner : CandySpawner = $CandySpawner
+
+## Lists scenes in the given resource directory, accounting for the fact that,
+## when exported, resource files are renamed, but must be loaded by their
+## original name.
+##
+## Returns the original basename of each scene in the given directory.
+##
+## TODO: in Godot 4.4, use ResourceLoader.list_directory()
+##  https://docs.godotengine.org/en/latest/classes/class_resourceloader.html#class-resourceloader-method-list-directory
+func _list_scenes(path: String) -> Array[String]:
+	var scenes: Array[String]
+	var dir := DirAccess.open(path)
+
+	dir.list_dir_begin()
+	var file := dir.get_next()
+	while file:
+		if file.ends_with(".tscn.remap"):
+			scenes.append(file.left(-len(".remap")))
+		elif file.ends_with(".tscn"):
+			scenes.append(file)
+		file = dir.get_next()
+	dir.list_dir_end()
+
+	return scenes
+
+## Load a series of numbered scenes from the given directory.
+## Each must be a TileMapLayer node.
+func _load_levels(level_directory: String):
+	var level_regexp := RegEx.create_from_string("^\\d+\\.tscn$")
+	var scenes := _list_scenes(level_directory).filter(func (filename: String): return level_regexp.search(filename))
+	scenes.sort_custom(func (a: String, b: String): return a.naturalnocasecmp_to(b) < 0)
+
+	for scene_filename in scenes:
+		var l := load(level_directory.path_join(scene_filename)) as PackedScene
+		levels.append(l)
+
+	lastLevel = levels.size() - 1
+
+func _ready() -> void:
+	_load_levels(self.scene_file_path.get_base_dir())
+	_instantiate_level()
+
+func _instantiate_level():
+	if _game:
+		remove_child(_game)
+		_game.queue_free()
+	
+	_game = _game_scene.instantiate()
+
+	# Replace the map in the scene with the real thing.
+	# TODO: make each level a fully-featured scene instead.
+	var dummy_map = _game.find_child("Map")
+	var real_map = levels[level].instantiate()
+	real_map.name = "Map"
+	dummy_map.replace_by(real_map)
+	dummy_map.queue_free()
+
+	if level == firstLevel:
+		_game.level_type = Game.LevelType.TITLE
+	elif level == lastLevel:
+		_game.level_type = Game.LevelType.COMPLETE
+
+	_game.win.connect(_on_win)
+	_game.lose.connect(_on_lose)
+	add_child(_game)
+	
+	_candy_spawner.progress = float(level - firstLevel) / (lastLevel - firstLevel)
+
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		get_tree().change_scene_to_file("res://Scene/WorldSelector.tscn")
+
+func _on_win():
+	level = posmod(level + 1, levels.size())
+	_instantiate_level()
+
+
+func _on_lose():
+	level = max(level - 1, firstLevel)
+	_instantiate_level()

--- a/Script/WorldSelector.gd
+++ b/Script/WorldSelector.gd
@@ -1,20 +1,15 @@
 extends Control
 
-var _game := preload("res://Scene/Game.tscn") as PackedScene
-
 @onready var MainWorldSelector = $MainWorldSelector
 @onready var ExtraWorldSelector = $ExtraWorldSelector
 
 
 func _enter_world(world: String) -> void:
-	global.load_levels(world)
-	global.level = global.firstLevel
-	get_tree().change_scene_to_packed(_game)
-	global.start_music()
+	get_tree().change_scene_to_file(world)
 
 
 func _on_main_world_selected() -> void:
-	_enter_world(global.DEFAULT_WORLD)
+	_enter_world("res://CandyWrapper/World.tscn")
 
 
 func _on_extra_worlds_button_pressed() -> void:

--- a/Script/WorldSelector/ExtraWorldSelector.gd
+++ b/Script/WorldSelector/ExtraWorldSelector.gd
@@ -29,7 +29,7 @@ func _ready() -> void:
 	for world in worlds:
 		var button = Button.new()
 		button.text = world
-		button.pressed.connect(_on_world_button_pressed.bind(WORLDS_DIR.path_join(world)))
+		button.pressed.connect(_on_world_button_pressed.bind(WORLDS_DIR.path_join(world).path_join("World.tscn")))
 		ExtraWorldsBox.add_child(button)
 
 

--- a/Worlds/Sample/World.tscn
+++ b/Worlds/Sample/World.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=4 format=3 uid="uid://dxlv7lxfy181n"]
+
+[ext_resource type="Script" path="res://Script/World.gd" id="1_2kgfm"]
+[ext_resource type="Script" path="res://Script/CandySpawner.gd" id="2_326lg"]
+[ext_resource type="AudioStream" uid="uid://7sq3il53l6oa" path="res://Audio/OST.mp3" id="2_pgqpj"]
+
+[node name="World" type="Node2D"]
+script = ExtResource("1_2kgfm")
+
+[node name="CandySpawner" type="Node2D" parent="."]
+script = ExtResource("2_326lg")
+
+[node name="Music" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("2_pgqpj")
+autoplay = true

--- a/Worlds/Sample/World.tscn
+++ b/Worlds/Sample/World.tscn
@@ -1,14 +1,13 @@
 [gd_scene load_steps=4 format=3 uid="uid://dxlv7lxfy181n"]
 
 [ext_resource type="Script" path="res://Script/World.gd" id="1_2kgfm"]
-[ext_resource type="Script" path="res://Script/CandySpawner.gd" id="2_326lg"]
 [ext_resource type="AudioStream" uid="uid://7sq3il53l6oa" path="res://Audio/OST.mp3" id="2_pgqpj"]
+[ext_resource type="PackedScene" uid="uid://ddy88bnd0h5it" path="res://Scene/CandySpawner.tscn" id="2_rive7"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("1_2kgfm")
 
-[node name="CandySpawner" type="Node2D" parent="."]
-script = ExtResource("2_326lg")
+[node name="CandySpawner" parent="." instance=ExtResource("2_rive7")]
 
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_pgqpj")

--- a/Worlds/Sample/World.tscn
+++ b/Worlds/Sample/World.tscn
@@ -1,14 +1,33 @@
-[gd_scene load_steps=4 format=3 uid="uid://dxlv7lxfy181n"]
+[gd_scene load_steps=7 format=3 uid="uid://dxlv7lxfy181n"]
 
 [ext_resource type="Script" path="res://Script/World.gd" id="1_2kgfm"]
 [ext_resource type="AudioStream" uid="uid://7sq3il53l6oa" path="res://Audio/OST.mp3" id="2_pgqpj"]
 [ext_resource type="PackedScene" uid="uid://ddy88bnd0h5it" path="res://Scene/CandySpawner.tscn" id="2_rive7"]
+[ext_resource type="Texture2D" uid="uid://ccxmd1v0nd7wi" path="res://Image/Title.png" id="4_5fw05"]
+[ext_resource type="AudioStream" uid="uid://bu4rmhfiu1mm5" path="res://Audio/Win.ogg" id="5_aa7p7"]
+[ext_resource type="AudioStream" uid="uid://dgnfi0xvfvhnx" path="res://Audio/Lose.wav" id="6_0fq84"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("1_2kgfm")
 
 [node name="CandySpawner" parent="." instance=ExtResource("2_rive7")]
 
+[node name="Overlay" type="Sprite2D" parent="."]
+visible = false
+z_index = 5
+texture = ExtResource("4_5fw05")
+centered = false
+hframes = 4
+frame = 1
+
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_pgqpj")
 autoplay = true
+
+[node name="Audio" type="Node" parent="."]
+
+[node name="Win" type="AudioStreamPlayer" parent="Audio"]
+stream = ExtResource("5_aa7p7")
+
+[node name="Lose" type="AudioStreamPlayer" parent="Audio"]
+stream = ExtResource("6_0fq84")


### PR DESCRIPTION
Previously, the top-level scene would either be WorldSelector or Game. To
transition between levels, Game would adjust a global variable containing the
current level number and then reload itself. When Game loads, it accesses that
global variable and instantiates the corresponding map.

This commit introduces a new World scene for each world, using a shared script.

When World is loaded, it loads all levels in its own directory, and then
instantiates the Game scene as a child, setting the first level as its map.
When the player wins or loses a level, Game now emits a signal. In response,
World replaces its child Game scene with a new instance, with the appropriate
map. Game grows a new property to trigger the special behaviour for the first
and last level, rather than checking global variables for this. As a result,
Game no longer accesses global variables.

CandySpawner moves from the Game scene to the World, so that World can adjust
the spawn rate based on progress through the worlds. As a result, CandySpawner
no longer accesses global variables. This also opens the possibility of
different worlds having a different texture falling in the background – or none
at all.

The background music moves from Global to World. Similarly, this allows
different worlds to have different background music.

Game has a simple Map so that the Game scene can be run in the editor.