### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,15 @@
+<!-- Thanks for opening a pull request! Please fill out the information below. -->
+
+## Summary of changes
+<!-- Please describe your changes below; if you're adding a world, include some information about why you designed your levels how you did. -->
+
+
+
+## Related issues
+<!-- If this pull request is related to an issue, mention it below by number (e.g. #1) -->
+
+
+
+## Screenshot
+<!-- If your pull request affects the visuals of the game, please include a screenshot of the changes below. If you're adding a world, include a screenshot of the levels. -->
+

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Thanks for opening a pull request! Please fill out the information below. -->
+<!-- Thanks for opening a pull request! Please ensure your title is descriptive and covers the WHAT (like "Worlds: add Cassidy's World" or "Player: Emit signals on contact with goobers"), then fill out the information below to explain the WHY and more details. -->
 
 ## Summary of changes
 <!-- Please describe your changes below; if you're adding a world, include some information about why you designed your levels how you did. -->


### PR DESCRIPTION
Just a simple starter template to encourage more detailed PR descriptions. Unfortunately I don't think we can easily have different templates like you can for issue templates, e.g. for adding a world vs. fixing something in the game. Still, this should help guide people a bit.