### PR TITLE
Normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf


### PR DESCRIPTION
Add a .gitattributes to normalize the line endings. A default Godot new project comes with this file and exactly this content if created with the "Version Control Metadata: Git" option.

Fix https://github.com/endlessm/everlasting-candy/issues/44