### PR TITLE
Snap transforms to pixels

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -126,6 +126,7 @@ ui_fullscreen={
 
 textures/canvas_textures/default_texture_filter=0
 environment/defaults/default_clear_color=Color(1, 0.984314, 0.8, 1)
+2d/snap/snap_2d_transforms_to_pixel=true
 environment/defaults/default_environment="res://default_env.tres"
 quality/driver/driver_name="GLES2"
 quality/2d/use_pixel_snap=true


### PR DESCRIPTION
This is a recommended setting for low resolution pixel-art games. Exactly this case. It will help instantiating Player or Goober scenes directly into the canvas.

Helps https://github.com/endlessm/everlasting-candy/issues/34