### PR TITLE
Level: Parametrise the Player and Goober scenes

### DIFF
--- a/Script/Level.gd
+++ b/Script/Level.gd
@@ -10,8 +10,13 @@ enum LevelType { NORMAL, TITLE, COMPLETE }
 enum {TILE_WALL = 0, TILE_PLAYER = 1, TILE_GOOBER = 2}
 @onready var Map: TileMapLayer = $Map
 
-var ScenePlayer = load("res://Scene/Player.tscn")
-var SceneGoober = load("res://Scene/Goober.tscn")
+## Any tiles from cell source ID TILE_PLAYER will be replaced by this scene
+## when the level runs. It should be an instance of Player.
+@export var player_scene := preload("res://Scene/Player.tscn")
+
+## Any tiles from cell source ID TILE_GOOBER will be replaced by this scene
+## when the level runs. It should be an instance of Goober.
+@export var goober_scene := preload("res://Scene/Goober.tscn")
 
 ## This scene is used when the player or a goober is destroyed.
 @export var explosion_scene := preload("res://Scene/Explosion.tscn")
@@ -44,14 +49,14 @@ func MapStart():
 				Map.set_cell(pos, TILE_WALL, atlas)
 			TILE_PLAYER:
 				# Add live player to the scene
-				var inst = ScenePlayer.instantiate()
+				var inst = player_scene.instantiate()
 				inst.position = Map.map_to_local(pos) + Vector2(4, 0)
 				self.add_child(inst)
 				# Remove static player tile from the tile map
 				Map.set_cell(pos, -1)
 			TILE_GOOBER:
 				# Add live goober to the scene
-				var inst = SceneGoober.instantiate()
+				var inst = goober_scene.instantiate()
 				inst.position = Map.map_to_local(pos) + Vector2(4, 0)
 				NodeGoobers.add_child(inst)
 				# Remove static goober tile from the tile map


### PR DESCRIPTION
Previously, the Level script had hardcoded references to the default
versions of these scenes. This means that (for example) even if you use a
TileMapLayer with a different TileSet that displays the player with a
different sprite, the default Player appearance would be used.

With this change, the Player could be customised for a given world (or
even a single level) by duplicating the Player scene, overriding its
sprites (but keeping the script the same), and then setting the
player_scene property on the level.