### PR TITLE
Goober: add 1px vertical offset

### DIFF
--- a/Scene/Goober.tscn
+++ b/Scene/Goober.tscn
@@ -38,20 +38,22 @@ collision_layer = 4
 script = ExtResource("1")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(0, -1)
 texture = ExtResource("2")
 hframes = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 1)
 shape = SubResource("1")
 
 [node name="Area2D" type="Area2D" parent="."]
+position = Vector2(0, 1)
 collision_layer = 4
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 shape = SubResource("2")
 
 [node name="RayCast2D" type="RayCast2D" parent="."]
+position = Vector2(0, 1)
 target_position = Vector2(0, 5)
 collide_with_areas = true
 

--- a/Script/Level.gd
+++ b/Script/Level.gd
@@ -48,7 +48,7 @@ func MapStart():
 			TILE_GOOBER:
 				# Add live goober to the scene
 				var inst = SceneGoober.instantiate()
-				inst.position = Map.map_to_local(pos) + Vector2(4, 1)
+				inst.position = Map.map_to_local(pos) + Vector2(4, 0)
 				NodeGoobers.add_child(inst)
 				# Remove static goober tile from the tile map
 				Map.set_cell(pos, -1)


### PR DESCRIPTION
Previously, when the Level placed the Goober into the scene, it would apply a 1px vertical offset to its position. This is because the goober is shorter than the 8×8px cell size, so its feet would not touch the floor if it were placed at the vertical centre of the cell.

Instead, apply the same offset inside the Goober scene, to its sprite, hitboxes (why does it have two?) and raycast. Remove the offset from the Level code that places it so that it is placed in the same way as the Player scene.