### PR TITLE
Level: Parametrise the Explosion scene

### DIFF
--- a/Script/Level.gd
+++ b/Script/Level.gd
@@ -12,7 +12,9 @@ enum {TILE_WALL = 0, TILE_PLAYER = 1, TILE_GOOBER = 2}
 
 var ScenePlayer = load("res://Scene/Player.tscn")
 var SceneGoober = load("res://Scene/Goober.tscn")
-var SceneExplo = load("res://Scene/Explosion.tscn")
+
+## This scene is used when the player or a goober is destroyed.
+@export var explosion_scene := preload("res://Scene/Explosion.tscn")
 
 @onready var NodeGoobers := $Goobers
 
@@ -63,7 +65,7 @@ func _process(_delta: float):
 			win.emit()
 
 func Explode(character: Node2D):
-	var xpl = SceneExplo.instantiate()
+	var xpl = explosion_scene.instantiate()
 	xpl.position = character.position
 	add_child(xpl)
 	character.queue_free()


### PR DESCRIPTION
The Level script instantiates an explosion when the player and a goober come into contact. The scene to instantiate is stored in an instance variable.

Mark this variable with @export to make it easier to override in the editor, without having to modify or extend the Level script. Switch from load() to preload() since the default path is a constant.

With this change, it is easier to, for example, create a new world where the “explosion” is a shower of magical sparkles rather than an explosion in the violent sense.