### PR TITLE
Use groups for players and goobers

### DIFF
--- a/Scene/Goober.tscn
+++ b/Scene/Goober.tscn
@@ -32,7 +32,7 @@ _data = {
 "Run": SubResource("3")
 }
 
-[node name="Goober" type="CharacterBody2D"]
+[node name="Goober" type="CharacterBody2D" groups=["goober"]]
 z_index = 9
 collision_layer = 4
 script = ExtResource("1")

--- a/Scene/Player.tscn
+++ b/Scene/Player.tscn
@@ -68,7 +68,7 @@ _data = {
 "Run": SubResource("5")
 }
 
-[node name="Player" type="CharacterBody2D"]
+[node name="Player" type="CharacterBody2D" groups=["player"]]
 z_index = 10
 collision_layer = 2
 script = ExtResource("1")

--- a/Script/Level.gd
+++ b/Script/Level.gd
@@ -28,6 +28,10 @@ func _ready():
 
 	MapStart()
 
+	for player in get_tree().get_nodes_in_group("player"):
+		player.died.connect(_on_died.bind(player))
+		player.stomped.connect(_on_stomped)
+
 func MapStart():
 	for pos in Map.get_used_cells():
 		var id = Map.get_cell_source_id(pos)
@@ -41,8 +45,6 @@ func MapStart():
 				var inst = ScenePlayer.instantiate()
 				inst.position = Map.map_to_local(pos) + Vector2(4, 0)
 				self.add_child(inst)
-				inst.died.connect(_on_died.bind(inst))
-				inst.stomped.connect(_on_stomped)
 				# Remove static player tile from the tile map
 				Map.set_cell(pos, -1)
 			TILE_GOOBER:

--- a/Script/Level.gd
+++ b/Script/Level.gd
@@ -59,7 +59,7 @@ func _process(_delta: float):
 	# should i check?
 	if check:
 		check = false
-		var count = NodeGoobers.get_child_count()
+		var count = get_tree().get_node_count_in_group("goober")
 		print("Goobers: ", count)
 		if count == 0:
 			win.emit()

--- a/project.godot
+++ b/project.godot
@@ -29,6 +29,10 @@ window/size/window_width_override=576
 window/size/window_height_override=576
 window/stretch/mode="canvas_items"
 
+[global_group]
+
+player=""
+
 [importer_defaults]
 
 texture={

--- a/project.godot
+++ b/project.godot
@@ -31,7 +31,7 @@ window/stretch/mode="canvas_items"
 
 [global_group]
 
-player=""
+player="The main character controlled by the player"
 goober="Enemies which must all be stomped"
 
 [importer_defaults]

--- a/project.godot
+++ b/project.godot
@@ -32,6 +32,7 @@ window/stretch/mode="canvas_items"
 [global_group]
 
 player=""
+goober="Enemies which must all be stomped"
 
 [importer_defaults]
 


### PR DESCRIPTION
Previously, when the Level script instantiated a Player scene based on a
tile in the TileMapLayer, its signals would be connected to handlers in
the Level class; but it was not easy to connect the signals on a Player
scene that had been instantiated into the level scene in the editor,
because the Player.died signal doesn't include a reference to the
emitting player, which the Level callback needs.

Create a new global group, `player`, and add the Player scene to that
group. Then, in `Level._ready()`, after the TileMapLayer has been
processed, connect to those signals on any members of that group which
are in the tree.

(This preserves the previous behaviour where, if you place two or more
players into the tilemap, they are all "live". I can imagine some
interesting level designs based on this behaviour!)

----

Previously, the Level would check whether any goobers remained by
counting the children of a Goobers node.

Instead, count members of a new `goober` group. This reduces the
requirement for a level to have a specific node hierarchy to work
correctly: if the level designer instantiates a goober directly into the
scene, somewhere other than as a child of a node called Goobers, the
level will still work correctly.

----

Helps #66