### PR TITLE
Use Object.connect() for player signals

### DIFF
--- a/Script/Level.gd
+++ b/Script/Level.gd
@@ -31,8 +31,8 @@ func _ready():
 	MapStart()
 
 	for player in get_tree().get_nodes_in_group("player"):
-		player.died.connect(_on_died.bind(player))
-		player.stomped.connect(_on_stomped)
+		player.connect(&"died", _on_died.bind(player))
+		player.connect(&"stomped", _on_stomped)
 
 func MapStart():
 	for pos in Map.get_used_cells():


### PR DESCRIPTION
Since commit bf38e462 the player signals are connected dynamically by traversing the group. However this fails at runtime with:

"Invalid access to property or key 'died' on a base object of type 'CharacterBody2D'."

This is because signal.connect() is used. That is the preferred way, except it doesn't work dynamically. So use Object.connect() passing the signal StringName instead.