### PR TITLE
TileSet: Remove static Player/Goober sprite source 

### DIFF
--- a/CandyWrapper/TileSet.tres
+++ b/CandyWrapper/TileSet.tres
@@ -1,8 +1,6 @@
-[gd_resource type="TileSet" load_steps=12 format=3 uid="uid://caem805hxljgn"]
+[gd_resource type="TileSet" load_steps=8 format=3 uid="uid://caem805hxljgn"]
 
 [ext_resource type="Texture2D" uid="uid://btfn40n148ymy" path="res://Image/Tilemap.png" id="1"]
-[ext_resource type="Texture2D" uid="uid://cboj002ecda55" path="res://Image/Player.png" id="2"]
-[ext_resource type="Texture2D" uid="uid://cn5awui7bqekp" path="res://Image/Goober.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://d24wavdwab2qx" path="res://Image/Explosion.png" id="4"]
 [ext_resource type="PackedScene" uid="uid://b17jmr687k1sm" path="res://Scene/Player.tscn" id="5_tc8rm"]
 [ext_resource type="PackedScene" uid="uid://byheefdx4lxmx" path="res://Scene/Goober.tscn" id="6_s0l86"]
@@ -30,18 +28,6 @@ texture_region_size = Vector2i(8, 8)
 2:2/0 = 0
 2:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-4, -4, 4, -4, 4, 4, -4, 4)
 
-[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_kvbjb"]
-texture = ExtResource("2")
-texture_region_size = Vector2i(8, 8)
-0:0/next_alternative_id = 8
-0:0/0 = 0
-
-[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_64w00"]
-texture = ExtResource("3")
-texture_region_size = Vector2i(8, 8)
-0:0/next_alternative_id = 8
-0:0/0 = 0
-
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_ye5km"]
 texture = ExtResource("4")
 margins = Vector2i(32, 0)
@@ -58,7 +44,5 @@ scenes/2/scene = ExtResource("6_s0l86")
 tile_size = Vector2i(8, 8)
 physics_layer_0/collision_layer = 1
 sources/0 = SubResource("TileSetAtlasSource_ltthb")
-sources/1 = SubResource("TileSetAtlasSource_kvbjb")
-sources/2 = SubResource("TileSetAtlasSource_64w00")
 sources/3 = SubResource("TileSetAtlasSource_ye5km")
 sources/4 = SubResource("TileSetScenesCollectionSource_odc7q")

--- a/Script/Level.gd
+++ b/Script/Level.gd
@@ -7,11 +7,8 @@ signal lose
 enum LevelType { NORMAL, TITLE, COMPLETE }
 @export var level_type := LevelType.NORMAL
 
-enum {TILE_WALL = 0, TILE_PLAYER = 1, TILE_GOOBER = 2}
+enum {TILE_WALL = 0}
 @onready var Map: TileMapLayer = $Map
-
-var ScenePlayer = load("res://Scene/Player.tscn")
-var SceneGoober = load("res://Scene/Goober.tscn")
 
 ## This scene is used when the player or a goober is destroyed.
 @export var explosion_scene := preload("res://Scene/Explosion.tscn")
@@ -46,20 +43,6 @@ func MapStart():
 				# Use random wall tile from 3×3 tileset to make levels look less repetitive
 				var atlas = Vector2(randi_range(0, 2), randi_range(0, 2))
 				Map.set_cell(pos, TILE_WALL, atlas)
-			TILE_PLAYER:
-				# Add live player to the scene
-				var inst = ScenePlayer.instantiate()
-				inst.position = Map.map_to_local(pos) + Vector2(4, 0)
-				self.add_child(inst)
-				# Remove static player tile from the tile map
-				Map.set_cell(pos, -1)
-			TILE_GOOBER:
-				# Add live goober to the scene
-				var inst = SceneGoober.instantiate()
-				inst.position = Map.map_to_local(pos) + Vector2(4, 0)
-				self.add_child(inst)
-				# Remove static goober tile from the tile map
-				Map.set_cell(pos, -1)
 
 func _process(_delta: float):
 	# should i check?

--- a/Worlds/Cassidy's Purple World/TileSet.tres
+++ b/Worlds/Cassidy's Purple World/TileSet.tres
@@ -1,8 +1,6 @@
-[gd_resource type="TileSet" load_steps=12 format=3 uid="uid://c6ssayef3wf6r"]
+[gd_resource type="TileSet" load_steps=8 format=3 uid="uid://c6ssayef3wf6r"]
 
 [ext_resource type="Texture2D" uid="uid://cxohcpdoqt6xd" path="res://Worlds/Cassidy's Purple World/Image/Tilemap.png" id="1_abdy0"]
-[ext_resource type="Texture2D" uid="uid://df3vdlh5fmjt1" path="res://Worlds/Cassidy's Purple World/Image/Player.png" id="2_uihpr"]
-[ext_resource type="Texture2D" uid="uid://cms8ap3qdoo7w" path="res://Worlds/Cassidy's Purple World/Image/Goober.png" id="3_bct37"]
 [ext_resource type="Texture2D" uid="uid://bg73osqh8tm3" path="res://Worlds/Cassidy's Purple World/Image/Explosion.png" id="4_g3o57"]
 [ext_resource type="PackedScene" uid="uid://cwishirmqclcm" path="res://Worlds/Cassidy's Purple World/Scene/Player.tscn" id="5_fjw1x"]
 [ext_resource type="PackedScene" uid="uid://cdn3mmnpx6230" path="res://Worlds/Cassidy's Purple World/Scene/Goober.tscn" id="6_rxfam"]
@@ -30,18 +28,6 @@ texture_region_size = Vector2i(8, 8)
 2:2/0 = 0
 2:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-4, -4, 4, -4, 4, 4, -4, 4)
 
-[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_kvbjb"]
-texture = ExtResource("2_uihpr")
-texture_region_size = Vector2i(8, 8)
-0:0/next_alternative_id = 8
-0:0/0 = 0
-
-[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_64w00"]
-texture = ExtResource("3_bct37")
-texture_region_size = Vector2i(8, 8)
-0:0/next_alternative_id = 8
-0:0/0 = 0
-
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_ye5km"]
 texture = ExtResource("4_g3o57")
 margins = Vector2i(32, 0)
@@ -58,7 +44,5 @@ scenes/2/scene = ExtResource("6_rxfam")
 tile_size = Vector2i(8, 8)
 physics_layer_0/collision_layer = 1
 sources/0 = SubResource("TileSetAtlasSource_ltthb")
-sources/1 = SubResource("TileSetAtlasSource_kvbjb")
-sources/2 = SubResource("TileSetAtlasSource_64w00")
 sources/3 = SubResource("TileSetAtlasSource_ye5km")
 sources/4 = SubResource("TileSetScenesCollectionSource_odc7q")


### PR DESCRIPTION
Now that all levels have been converted to use the
TileSetSceneCollectionSource for these actors, we can remove the old static sources from the TileSet.

Notice that the source IDs for the subsequent sources do not change,
which means the TileMapLayer nodes do not need to be updated.

----

This was not part of #68 because we have many learner levels in the wild that will need to be updated, or else they will break when this is merged.

I used https://github.com/endlessm/everlasting-candy/commit/6bada25a4aa8d57bbc44bbcc589586e96ee1b57f to convert all the levels:

1. Apply that patch
2. (Re)open every level (you can use multi-select in the `FileSystem` dock)
3. Save every level (`Ctrl+Shift+Alt+S` or Scene → Save All Scenes)

