### PR TITLE
Add Settings page with volume controls

### DIFF
--- a/CandyWrapper/World.tscn
+++ b/CandyWrapper/World.tscn
@@ -28,11 +28,14 @@ frame = 1
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_swba7")
 autoplay = true
+bus = &"Music"
 
 [node name="Audio" type="Node" parent="."]
 
 [node name="Win" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("5_qdrvr")
+bus = &"Sfx"
 
 [node name="Lose" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("6_rs0e0")
+bus = &"Sfx"

--- a/Scene/Explosion.tscn
+++ b/Scene/Explosion.tscn
@@ -48,6 +48,7 @@ frame = 1
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("3")
 autoplay = true
+bus = &"Sfx"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/Scene/Player.tscn
+++ b/Scene/Player.tscn
@@ -91,6 +91,7 @@ shape = SubResource("2")
 
 [node name="Audio" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("3")
+bus = &"Sfx"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/Scene/WorldSelector.tscn
+++ b/Scene/WorldSelector.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://h6eyk0hg1y1f"]
+[gd_scene load_steps=6 format=3 uid="uid://h6eyk0hg1y1f"]
 
 [ext_resource type="Theme" uid="uid://dqt6eyc0l8kms" path="res://Theme/WorldSelector.tres" id="1_h1u7b"]
 [ext_resource type="Script" path="res://Script/WorldSelector.gd" id="2_c1jjg"]
 [ext_resource type="PackedScene" uid="uid://b1qffdabwqnxf" path="res://Scene/WorldSelector/ExtraWorldSelector.tscn" id="3_d8a1w"]
 [ext_resource type="PackedScene" uid="uid://pnnwgl5j385l" path="res://Scene/WorldSelector/MainWorldSelector.tscn" id="3_dc6jw"]
+[ext_resource type="PackedScene" uid="uid://d2ay7olsehadk" path="res://Scene/WorldSelector/SettingsPage.tscn" id="5_opwul"]
 
 [node name="TitleScreen" type="Control"]
 layout_mode = 3
@@ -22,7 +23,13 @@ layout_mode = 1
 visible = false
 layout_mode = 1
 
+[node name="SettingsPage" parent="." instance=ExtResource("5_opwul")]
+visible = false
+layout_mode = 1
+
 [connection signal="main_world_selected" from="MainWorldSelector" to="." method="_on_main_world_selected"]
+[connection signal="settings_selected" from="MainWorldSelector" to="." method="_on_main_world_selector_settings_selected"]
 [connection signal="show_extra_worlds" from="MainWorldSelector" to="." method="_on_extra_worlds_button_pressed"]
 [connection signal="back" from="ExtraWorldSelector" to="." method="_on_back_button_pressed"]
 [connection signal="world_selected" from="ExtraWorldSelector" to="." method="_enter_world"]
+[connection signal="back" from="SettingsPage" to="." method="_on_settings_page_back"]

--- a/Scene/WorldSelector/MainWorldSelector.tscn
+++ b/Scene/WorldSelector/MainWorldSelector.tscn
@@ -46,6 +46,11 @@ text = "Play Candy Wrapper"
 layout_mode = 2
 text = "Extra Worlds"
 
+[node name="Settings" type="Button" parent="VBox/MarginContainer2/MainWorldBox"]
+layout_mode = 2
+text = "Settings"
+
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
 [connection signal="pressed" from="VBox/MarginContainer2/MainWorldBox/CandyWrapperButton" to="." method="_on_candy_wrapper_button_pressed"]
 [connection signal="pressed" from="VBox/MarginContainer2/MainWorldBox/ExtraWorldsButton" to="." method="_on_extra_worlds_button_pressed"]
+[connection signal="pressed" from="VBox/MarginContainer2/MainWorldBox/Settings" to="." method="_on_settings_button_pressed"]

--- a/Scene/WorldSelector/SettingsPage.tscn
+++ b/Scene/WorldSelector/SettingsPage.tscn
@@ -1,0 +1,76 @@
+[gd_scene load_steps=3 format=3 uid="uid://d2ay7olsehadk"]
+
+[ext_resource type="Theme" uid="uid://dqt6eyc0l8kms" path="res://Theme/WorldSelector.tres" id="1_gll88"]
+[ext_resource type="Script" path="res://Script/WorldSelector/SettingsPage.gd" id="2_6mi7e"]
+
+[node name="SettingsPage" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_gll88")
+script = ExtResource("2_6mi7e")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+offset_right = 140.0
+offset_bottom = 144.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+theme_type_variation = &"HeaderLarge"
+text = "Settings"
+horizontal_alignment = 1
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_right = 1
+theme_override_constants/margin_bottom = 5
+
+[node name="ExtraWorldsBox" type="VBoxContainer" parent="VBoxContainer/MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 2
+
+[node name="MusicLabel" type="Label" parent="VBoxContainer/MarginContainer/ExtraWorldsBox"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"HeaderLarge"
+theme_override_font_sizes/font_size = 9
+text = "music"
+horizontal_alignment = 1
+
+[node name="MusicSlider" type="HSlider" parent="VBoxContainer/MarginContainer/ExtraWorldsBox"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = -30.0
+max_value = 0.0
+
+[node name="SfxLabel" type="Label" parent="VBoxContainer/MarginContainer/ExtraWorldsBox"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"HeaderLarge"
+theme_override_font_sizes/font_size = 9
+text = "sfx"
+horizontal_alignment = 1
+
+[node name="SfxSlider" type="HSlider" parent="VBoxContainer/MarginContainer/ExtraWorldsBox"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = -30.0
+max_value = 0.0
+
+[node name="BackButton" type="Button" parent="VBoxContainer/MarginContainer/ExtraWorldsBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Go Back"
+
+[connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
+[connection signal="pressed" from="VBoxContainer/MarginContainer/ExtraWorldsBox/BackButton" to="." method="_on_back_button_pressed"]

--- a/Script/Settings.gd
+++ b/Script/Settings.gd
@@ -1,0 +1,50 @@
+extends Node
+
+const SETTINGS_PATH := "user://settings.cfg"
+
+const VOLUME_SECTION := "Volume"
+const MIN_VOLUME := -30.0
+
+var _settings := ConfigFile.new()
+
+
+func _ready() -> void:
+	var err := _settings.load(SETTINGS_PATH)
+	if err != OK and err != ERR_FILE_NOT_FOUND:
+		print("Failed to load %s: %s" % [SETTINGS_PATH, err])
+
+	_restore_volumes()
+
+
+func _restore_volumes() -> void:
+	for bus_idx in AudioServer.bus_count:
+		var bus := AudioServer.get_bus_name(bus_idx)
+		var volume_db : float = _settings.get_value(VOLUME_SECTION, bus, 0.0)
+		print("Restored", [bus_idx, bus, volume_db])
+		_set_volume(bus_idx, volume_db)
+
+
+func get_volume(bus: String) -> float:
+	var bus_idx = AudioServer.get_bus_index(bus)
+
+	return AudioServer.get_bus_volume_db(bus_idx)
+
+
+func set_volume(bus: String, volume_db: float) -> void:
+	var bus_idx = AudioServer.get_bus_index(bus)
+	_set_volume(bus_idx, volume_db)
+
+	_settings.set_value(VOLUME_SECTION, bus, volume_db)
+	_save()
+
+
+func _set_volume(bus_idx: int, volume_db: float) -> void:
+	AudioServer.set_bus_volume_db(bus_idx, volume_db)
+	var mute := volume_db <= MIN_VOLUME
+	AudioServer.set_bus_mute(bus_idx, mute)
+
+
+func _save():
+	var err := _settings.save(SETTINGS_PATH)
+	if err != OK:
+		print("Failed to save settings to %s: %s" % [SETTINGS_PATH, err])

--- a/Script/WorldSelector.gd
+++ b/Script/WorldSelector.gd
@@ -2,7 +2,7 @@ extends Control
 
 @onready var MainWorldSelector = $MainWorldSelector
 @onready var ExtraWorldSelector = $ExtraWorldSelector
-
+@onready var SettingsPage = $SettingsPage
 
 func _enter_world(world: String) -> void:
 	get_tree().change_scene_to_file(world)
@@ -19,4 +19,14 @@ func _on_extra_worlds_button_pressed() -> void:
 
 func _on_back_button_pressed() -> void:
 	ExtraWorldSelector.visible = false
+	MainWorldSelector.visible = true
+
+
+func _on_main_world_selector_settings_selected() -> void:
+	MainWorldSelector.visible = false
+	SettingsPage.visible = true
+
+
+func _on_settings_page_back() -> void:
+	SettingsPage.visible = false
 	MainWorldSelector.visible = true

--- a/Script/WorldSelector/MainWorldSelector.gd
+++ b/Script/WorldSelector/MainWorldSelector.gd
@@ -2,6 +2,7 @@ extends Control
 
 signal main_world_selected
 signal show_extra_worlds
+signal settings_selected
 
 @onready var CandyWrapperButton = %CandyWrapperButton
 
@@ -20,3 +21,7 @@ func _on_extra_worlds_button_pressed() -> void:
 func _on_visibility_changed() -> void:
 	if self.visible and CandyWrapperButton:
 		CandyWrapperButton.grab_focus()
+
+
+func _on_settings_button_pressed() -> void:
+	settings_selected.emit()

--- a/Script/WorldSelector/SettingsPage.gd
+++ b/Script/WorldSelector/SettingsPage.gd
@@ -1,0 +1,56 @@
+extends Control
+
+signal back
+
+const SETTINGS_PATH := "user://settings.cfg"
+const VOLUME_SECTION := "Volume"
+var _settings := ConfigFile.new()
+var _loading = true
+
+@onready var music_slider : HSlider = %MusicSlider
+@onready var sfx_slider : HSlider = %SfxSlider
+
+func _ready() -> void:
+	var err := _settings.load(SETTINGS_PATH)
+	if err != OK and err != ERR_FILE_NOT_FOUND:
+		print("Failed to load %s: %s" % [SETTINGS_PATH, err])
+
+	_initialise_slider(music_slider, "Music")
+	_initialise_slider(sfx_slider, "Sfx")
+
+	_loading = false
+
+
+func _initialise_slider(slider: Slider, bus: String):
+	var level = _settings.get_value(VOLUME_SECTION, bus, 0)
+
+	slider.value_changed.connect(_on_slider_value_changed.bind(slider, bus))
+	slider.value = level
+
+
+func _on_slider_value_changed(value: float, slider: Slider, bus: String) -> void:
+	var bus_idx = AudioServer.get_bus_index(bus)
+
+	AudioServer.set_bus_volume_db(bus_idx, value)
+	var mute := value == slider.min_value
+	AudioServer.set_bus_mute(bus_idx, mute)
+
+	if not _loading:
+		_settings.set_value(VOLUME_SECTION, bus, value)
+		var err := _settings.save(SETTINGS_PATH)
+		if err != OK:
+			print("Failed to save settings to %s: %s" % [SETTINGS_PATH, err])
+
+
+func _on_visibility_changed() -> void:
+	if self.visible and music_slider:
+		music_slider.grab_focus()
+
+
+func _input(event: InputEvent) -> void:
+	if self.visible and event.is_action_pressed("ui_cancel"):
+		back.emit()
+
+
+func _on_back_button_pressed() -> void:
+	back.emit()

--- a/Script/WorldSelector/SettingsPage.gd
+++ b/Script/WorldSelector/SettingsPage.gd
@@ -2,44 +2,21 @@ extends Control
 
 signal back
 
-const SETTINGS_PATH := "user://settings.cfg"
-const VOLUME_SECTION := "Volume"
-var _settings := ConfigFile.new()
-var _loading = true
-
 @onready var music_slider : HSlider = %MusicSlider
 @onready var sfx_slider : HSlider = %SfxSlider
 
 func _ready() -> void:
-	var err := _settings.load(SETTINGS_PATH)
-	if err != OK and err != ERR_FILE_NOT_FOUND:
-		print("Failed to load %s: %s" % [SETTINGS_PATH, err])
-
 	_initialise_slider(music_slider, "Music")
 	_initialise_slider(sfx_slider, "Sfx")
 
-	_loading = false
-
 
 func _initialise_slider(slider: Slider, bus: String):
-	var level = _settings.get_value(VOLUME_SECTION, bus, 0)
-
-	slider.value_changed.connect(_on_slider_value_changed.bind(slider, bus))
-	slider.value = level
+	slider.value = Settings.get_volume(bus)
+	slider.value_changed.connect(_on_slider_value_changed.bind(bus))
 
 
-func _on_slider_value_changed(value: float, slider: Slider, bus: String) -> void:
-	var bus_idx = AudioServer.get_bus_index(bus)
-
-	AudioServer.set_bus_volume_db(bus_idx, value)
-	var mute := value == slider.min_value
-	AudioServer.set_bus_mute(bus_idx, mute)
-
-	if not _loading:
-		_settings.set_value(VOLUME_SECTION, bus, value)
-		var err := _settings.save(SETTINGS_PATH)
-		if err != OK:
-			print("Failed to save settings to %s: %s" % [SETTINGS_PATH, err])
+func _on_slider_value_changed(value: float, bus: String) -> void:
+	Settings.set_volume(bus, value)
 
 
 func _on_visibility_changed() -> void:

--- a/Worlds/Cassidy's Purple World/Scene/Explosion.tscn
+++ b/Worlds/Cassidy's Purple World/Scene/Explosion.tscn
@@ -48,6 +48,7 @@ frame = 1
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_u3wti")
 autoplay = true
+bus = &"Sfx"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/Worlds/Cassidy's Purple World/Scene/Player.tscn
+++ b/Worlds/Cassidy's Purple World/Scene/Player.tscn
@@ -91,6 +91,7 @@ shape = SubResource("2")
 
 [node name="Audio" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("3_ea3of")
+bus = &"Sfx"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/Worlds/Cassidy's Purple World/World.tscn
+++ b/Worlds/Cassidy's Purple World/World.tscn
@@ -30,11 +30,14 @@ frame = 1
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_21637")
 autoplay = true
+bus = &"Music"
 
 [node name="Audio" type="Node" parent="."]
 
 [node name="Win" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("5_q65sc")
+bus = &"Sfx"
 
 [node name="Lose" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("6_upqr8")
+bus = &"Sfx"

--- a/Worlds/Sample/World.tscn
+++ b/Worlds/Sample/World.tscn
@@ -28,11 +28,14 @@ frame = 1
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_pgqpj")
 autoplay = true
+bus = &"Music"
 
 [node name="Audio" type="Node" parent="."]
 
 [node name="Win" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("5_aa7p7")
+bus = &"Sfx"
 
 [node name="Lose" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("6_0fq84")
+bus = &"Sfx"

--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,0 +1,15 @@
+[gd_resource type="AudioBusLayout" format=3 uid="uid://dedcyh6mnrxw5"]
+
+[resource]
+bus/1/name = &"Sfx"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_fx = false
+bus/1/volume_db = 0.0
+bus/1/send = &"Master"
+bus/2/name = &"Music"
+bus/2/solo = false
+bus/2/mute = false
+bus/2/bypass_fx = false
+bus/2/volume_db = 0.0
+bus/2/send = &"Master"

--- a/project.godot
+++ b/project.godot
@@ -20,6 +20,7 @@ config/icon="res://Image/picon.svg"
 [autoload]
 
 global="*res://Script/Global.gd"
+Settings="*res://Script/Settings.gd"
 
 [display]
 


### PR DESCRIPTION
Add two audio buses, Music and Sfx, and assign all audio nodes in the project to the appropriate bus.

Add a Settings page with one slider per bus. Persist the values to a config file, and restore them when the Settings scene is instantiated (which happens when the game is launched).

@Snowsd did the bulk of the work here (thanks!); I applied my review comments from #48 and added code to save & restore the volume levels.