### PR TITLE
World: Don't advance to level 1 twice

### DIFF
--- a/Script/World.gd
+++ b/Script/World.gd
@@ -66,14 +66,15 @@ func _instantiate_level():
 	_level_scene.lose.connect(_on_lose)
 	_candy_spawner.add_sibling(_level_scene)
 
-	if level == firstLevel:
-		NodeOverlay.visible = true
-		NodeOverlay.frame = 0
-	elif level == lastLevel:
-		NodeOverlay.visible = true
-		NodeOverlay.frame = 3
-	else:
-		NodeOverlay.visible = false
+	match _level_scene.level_type:
+		Level.LevelType.TITLE:
+			NodeOverlay.visible = true
+			NodeOverlay.frame = 0
+		Level.LevelType.COMPLETE:
+			NodeOverlay.visible = true
+			NodeOverlay.frame = 3
+		_:
+			NodeOverlay.visible = false
 
 	_candy_spawner.progress = float(level - firstLevel) / (lastLevel - firstLevel)
 

--- a/Script/World.gd
+++ b/Script/World.gd
@@ -84,7 +84,7 @@ func _input(event: InputEvent) -> void:
 		get_tree().change_scene_to_file("res://Scene/WorldSelector.tscn")
 
 func _process(_delta: float):
-	if Input.is_action_just_pressed("jump") and (level == firstLevel or level == lastLevel):
+	if Input.is_action_just_pressed("jump") and _level_scene.level_type != Level.LevelType.NORMAL:
 		level = posmod(level + 1, levels.size())
 		_instantiate_level()
 


### PR DESCRIPTION
Consider the following steps:

1. Start world
2. Press jump on title screen to advance from level 0 to level 1
3. On level 1, die
4. During the 1.5-second timeout where “YOU LOSE” is shown, before the
   title is re-shown, press jump

The expected result (IMO) is that nothing happens. Once the title screen
is shown again, pressing jump should start level 1 afresh.

But what would previously happen is that the code path for “jump pressed
while on title screen” would be followed, starting level 1. But then
once the 1.5-second timeout is complete, level 1 would be re-started. This
is because `level` is adjusted before the 1.5-second timeout begins.

To fix this, in World's input handler, check the level_type of the
currently-displayed Level, rather than the `level` variable, when
deciding whether to act on the jump action.