### PR TITLE
ci: Publish to GitHub Pages on each push to main

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,9 +1,9 @@
 name: "Publish to GitHub Pages"
 on:
   workflow_dispatch:
-  release:
-    types:
-      - published
+  push:
+    branches:
+      - main
 
 # Cancel any ongoing previous run if the job is re-triggered
 concurrency:


### PR DESCRIPTION
Previously, this project would only be built & published to https://endlessm.github.io/everlasting-candy/ when we make a release or manually run the workflow. This was inherited from the moddable minigames, where we do actually make releases which also get published to the Godot Asset Library.

The primary goal of this project is to add new worlds to explore and stretch the mechanics of the original game. There's real value in having people's contributions be available to play as soon as they are merged, without the ceremony of making a release, and I see no real reason not to.

Adjust the workflow to run on pushes to main, rather than on release.