### PR TITLE
Cgm-Dali/FelipeWorld: Add audio nodes to correct buses

### DIFF
--- a/Worlds/Cgm-Dali/World.tscn
+++ b/Worlds/Cgm-Dali/World.tscn
@@ -23,11 +23,14 @@ frame = 1
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_3cjeb")
 autoplay = true
+bus = &"Music"
 
 [node name="Audio" type="Node" parent="."]
 
 [node name="Win" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("5_ajn05")
+bus = &"Sfx"
 
 [node name="Lose" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("6_wksso")
+bus = &"Sfx"

--- a/Worlds/FelipeWorld/World.tscn
+++ b/Worlds/FelipeWorld/World.tscn
@@ -23,11 +23,14 @@ frame = 1
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_nflrt")
 autoplay = true
+bus = &"Music"
 
 [node name="Audio" type="Node" parent="."]
 
 [node name="Win" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("5_x3a8q")
+bus = &"Sfx"
 
 [node name="Lose" type="AudioStreamPlayer" parent="Audio"]
 stream = ExtResource("6_cv8sp")
+bus = &"Sfx"


### PR DESCRIPTION
While reviewing/updating these worlds, I didn't notice that they predated the addition of separate audio buses for Music/Sfx so the volume can be controlled.

Add the appropriate buses to the audio nodes in the two worlds.