### PR TITLE
CandySpawner: Don't set z-index

### DIFF
--- a/Script/CandySpawner.gd
+++ b/Script/CandySpawner.gd
@@ -51,7 +51,6 @@ func _process(delta):
 		else:
 			c = Sprite2D.new()
 			c.texture = candy_texture
-			c.z_index = -1
 			add_child(c)
 		active.append(c)
 		c.position.y = -16


### PR DESCRIPTION
Commit 576bd84a8f05abfb6639454b62de0bec2c73ad74 added a ColorRect to each world, with the default z_index (0). This covers the falling candies, which previously had z_index set to -1.

Remove the z_index from the candy sprites, leaving them at the default (0) and relying on the stacking order of the scene instead.

Fixes #92.