### PR TITLE
Publish all branches to GitHub Pages

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -1,0 +1,70 @@
+name: "Build and Export Game"
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GODOT_VERSION: 4.3
+
+jobs:
+  build:
+    name: Build for web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Godot Engine downloads
+        id: cache-godot
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/godot
+            build/._sc_
+            build/editor_data/export_templates/${{ env.GODOT_VERSION }}.stable
+          key: godot-${{ env.GODOT_VERSION }}
+
+      - name: Download Godot Engine from GitHub release
+        id: download
+        if: steps.cache-godot.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p build && cd build
+
+          # Download Godot Engine itself
+          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
+          unzip Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
+          mv Godot_v${GODOT_VERSION}-stable_linux.x86_64 godot
+
+          # Download export templates
+          mkdir -p editor_data/export_templates
+          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
+          unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
+          mv templates editor_data/export_templates/${GODOT_VERSION}.stable
+
+          # Tell Godot Engine to run in "self-contained" mode so it looks for
+          # templates here instead of in ~/.local/share/godot/
+          touch ._sc_
+
+      - name: Web Build
+        run: |
+          mkdir -v -p build/web && cd build
+
+          # Note that the export path can be confusing; it's relative to the
+          # Godot project path, NOT necessarily the current directory or Godot
+          # binary location
+          ./godot --headless --verbose --path ../ --export-release "Web" ./build/web/index.html
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web
+          path: build/web

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,9 +1,11 @@
 name: "Publish to GitHub Pages"
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - "Build and Export Game"
+    types:
+      - completed
 
 # Cancel any ongoing previous run if the job is re-triggered
 concurrency:
@@ -14,9 +16,6 @@ permissions:
   contents: read
   pages: write
   id-token: write
-
-env:
-  GODOT_VERSION: 4.3
 
 jobs:
   check:
@@ -40,77 +39,14 @@ jobs:
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
 
-  build:
-    name: Build for web
+  publish:
+    name: Publish all branches to GitHub Pages
     needs:
       - check
     if: ${{ needs.check.outputs.enabled }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: endlessm/amalgamate-pages@v1
         with:
-          lfs: true
-
-      - name: Cache Godot Engine downloads
-        id: cache-godot
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/godot
-            build/._sc_
-            build/editor_data/export_templates/${{ env.GODOT_VERSION }}.stable
-          key: godot-${{ env.GODOT_VERSION }}
-
-      - name: Download Godot Engine from GitHub release
-        id: download
-        if: steps.cache-godot.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p build && cd build
-
-          # Download Godot Engine itself
-          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
-          unzip Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
-          mv Godot_v${GODOT_VERSION}-stable_linux.x86_64 godot
-
-          # Download export templates
-          mkdir -p editor_data/export_templates
-          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
-          unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
-          mv templates editor_data/export_templates/${GODOT_VERSION}.stable
-
-          # Tell Godot Engine to run in "self-contained" mode so it looks for
-          # templates here instead of in ~/.local/share/godot/
-          touch ._sc_
-
-      - name: Web Build
-        run: |
-          mkdir -v -p build/web && cd build
-
-          # Note that the export path can be confusing; it's relative to the
-          # Godot project path, NOT necessarily the current directory or Godot
-          # binary location
-          ./godot --headless --verbose --path ../ --export-release "Web" ./build/web/index.html
-
-      - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          name: web
-          path: build/web
-
-  publish:
-    name: Publish to GitHub Pages
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    steps:
-      - id: deploy
-        name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
-        with:
+          workflow_name: "Build and Export Game"
           artifact_name: web
-
-      - name: Show URL in summary
-        if: ${{ steps.deploy.outcome == 'success' }}
-        run: |
-          echo "Game published to: <${{ steps.deploy.outputs.page_url }}>" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
I have [written an action](https://github.com/endlessm/amalgamate-pages) that finds the latest build from each branch, merges them into a single site, and publishes it to GitHub Pages.

Split the current workflow into two, with the following changes:

- `export.yml` unconditionally builds the site for the web (without checking if Pages is enabled), uploads a normal artifact (not a pages artifact), then stops.
- `github-pages.yml` is triggered not by pushes but by the export workflow succeeding (on any branch); it uses the new action to merge the artifacts into a single site and publish it.